### PR TITLE
feat(ms-buscador): security filters based on API Gateway Headers

### DIFF
--- a/gateway/src/main/resources/application.properties
+++ b/gateway/src/main/resources/application.properties
@@ -12,7 +12,9 @@ spring.cloud.gateway.globalcors.corsConfigurations['[/**]'].allowedOrigins='*'
 
 spring.cloud.gateway.routes[0].id=ms-buscador
 spring.cloud.gateway.routes[0].uri=lb://ms-buscador
-spring.cloud.gateway.routes[0].predicates[0]=Path=/api/product
+spring.cloud.gateway.routes[0].predicates[0]=Path=/buscador/**
+spring.cloud.gateway.routes[0].filters[0]=RewritePath=/buscador/?(?<segment>.*), /$\{segment}
+spring.cloud.gateway.routes[0].filters[1]=AddRequestHeader=X-Gateway-Secret, only-api-gateway-secret
 
 management.endpoints.web.exposure.include=*
 management.endpoint.gateway.enabled=true

--- a/ms-buscador/src/main/java/com/grupo1/ms_buscador/books/infrastructure/controllers/BookController.java
+++ b/ms-buscador/src/main/java/com/grupo1/ms_buscador/books/infrastructure/controllers/BookController.java
@@ -113,4 +113,8 @@ public class BookController {
         }
     }
 
+    @GetMapping("/test")
+    public String test() {
+        return "Hello from books";
+    }
 }

--- a/ms-buscador/src/main/java/com/grupo1/ms_buscador/core/infrastructure/filters/GatewayOnlyFilter.java
+++ b/ms-buscador/src/main/java/com/grupo1/ms_buscador/core/infrastructure/filters/GatewayOnlyFilter.java
@@ -1,0 +1,33 @@
+package com.grupo1.ms_buscador.core.infrastructure.filters;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import java.io.IOException;
+
+@Component
+public class GatewayOnlyFilter implements Filter {
+
+    @Value("${security.gateway.secret}")
+    private String gatewaySecret;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        String secretHeader = httpRequest.getHeader("X-Gateway-Secret");
+
+        // Bloquea la petición si no contiene el header correcto
+        if (secretHeader == null || !secretHeader.equals(gatewaySecret)) {
+            throw new SecurityException("Acceso denegado. Debes pasar por el API Gateway.");
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/ms-buscador/src/main/resources/application.properties
+++ b/ms-buscador/src/main/resources/application.properties
@@ -13,3 +13,5 @@ eureka.client.serviceUrl.defaultZone=http://eureka:8761/eureka
 eureka.client.register-with-eureka=true
 eureka.client.fetch-registry=true
 eureka.instance.prefer-ip-address=true
+
+security.gateway.secret=only-api-gateway-secret


### PR DESCRIPTION
- Seguridad para el microservicio buscador: Filtro GatewayOnlyFilter para validar que exista el header X-Gateway-Secret con una contraseña en específico, que debe enviar API Gateway
- Mapeo de endpoints: Ahora en vez de acceder mediante /ms-buscador/books, se debe acceder mediante /buscador/books
- Cabecera  X-Gateway-Secret desde API Gateway: La cabecera  X-Gateway-Secret con su valor correspondiente se envía en todas las peticiones hacia el microservicio buscador